### PR TITLE
chore: Do not publish version tag if version ends in `-SNAPSHOT`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,7 @@ jib {
     tags =
       when {
         project.version.toString().contains("-dev") -> setOf("unstable")
+        project.version.toString().contains("-SNAPSHOT") -> setOf("unstable")
         else -> setOf("stable", "latest", project.version.toString())
       }
     auth {


### PR DESCRIPTION
It will still be published as `unstable`